### PR TITLE
Temporarily rename some files at build time

### DIFF
--- a/io.github.qtox.qTox.json
+++ b/io.github.qtox.qTox.json
@@ -5,6 +5,8 @@
 	"runtime-version": "5.10",
 	"command": "qtox",
 	"rename-icon": "qtox",
+	"rename-desktop-file": "qtox.desktop",
+	"rename-appdata-file": "qTox.appdata.xml",
 	"finish-args": [
 		"--share=network",
 		"--socket=pulseaudio",


### PR DESCRIPTION
Temporarily add "rename-desktop-file" and "rename-appdata-file" to .json file to allow building until the new qTox version is out (https://github.com/flathub/flathub/pull/379#issuecomment-389324979)